### PR TITLE
set the headers for hpack + stack

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -50,9 +50,10 @@ extra-libraries:
   - openvr_api
 
 include-dirs:
-  - openvr/headers
   - cbits
 
+extra-include-dirs:
+  - openvr/headers
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -62,7 +62,7 @@ extra-package-dbs: []
 # arch: x86_64
 #
 # Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
+extra-include-dirs: [openvr/headrs, cbits]
 # extra-lib-dirs: [/path/to/dir]
 #
 # Allow a newer minor version of GHC than the snapshot specifies

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,9 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps: []
 
+include-dirs:
+    - openvr/headers
+
 # Override default flag values for local packages and extra-deps
 flags: {}
 


### PR DESCRIPTION
Fixes some build system corner cases. Some still need to provide `--extra-lib-dirs=/usr/local/lib` for a complete build.